### PR TITLE
Fix underflow issue, optimize storage reads, tests

### DIFF
--- a/src/ClubSig.sol
+++ b/src/ClubSig.sol
@@ -254,7 +254,7 @@ contract ClubSig is ClubNFT, Multicall {
 
         if (length != mints_.length) revert NoArrayParity();
 
-        uint256 nftSupply;
+        uint256 totalSupply_ = totalSupply;
         uint256 lootSupply;
         for (uint256 i = 0; i < length;) {
             if (mints_[i]) {
@@ -262,11 +262,11 @@ contract ClubSig is ClubNFT, Multicall {
 
                 // cannot realistically overflow on human timescales
                 unchecked {
-                    nftSupply++;
+                    totalSupply_++;
                 }
             } else {
                 _burn(club_[i].id);
-                nftSupply--;
+                totalSupply_--;
             }
             if (club_[i].loot != 0) {
                 loot[club_[i].signer] += club_[i].loot;
@@ -279,13 +279,12 @@ contract ClubSig is ClubNFT, Multicall {
             }
         }
 
-        uint256 totalSupply_ = totalSupply + nftSupply;
         if (lootSupply != 0) totalLoot += lootSupply;
         // note: also make sure that signers don't concentrate NFTs,
         // since this could cause issues in reaching quorum
         if (quorum_ > totalSupply_) revert SigBounds();
 
-        if (nftSupply != 0) totalSupply = totalSupply_;
+        totalSupply = totalSupply_;
         quorum = quorum_;
 
         emit Govern(club_, mints_, quorum_);

--- a/src/ClubSig.sol
+++ b/src/ClubSig.sol
@@ -279,12 +279,13 @@ contract ClubSig is ClubNFT, Multicall {
             }
         }
 
-        if (nftSupply != 0) totalSupply += nftSupply;
+        uint256 totalSupply_ = totalSupply + nftSupply;
         if (lootSupply != 0) totalLoot += lootSupply;
         // note: also make sure that signers don't concentrate NFTs,
         // since this could cause issues in reaching quorum
-        if (quorum_ > totalSupply) revert SigBounds();
+        if (quorum_ > totalSupply_) revert SigBounds();
 
+        if (nftSupply != 0) totalSupply = totalSupply_;
         quorum = quorum_;
 
         emit Govern(club_, mints_, quorum_);

--- a/src/test/ClubSig.t.sol
+++ b/src/test/ClubSig.t.sol
@@ -53,7 +53,7 @@ contract ClubSigTest is DSTestPlus {
       clubSig.govern(clubs, mints, 3);
     }
 
-    function testGovern() public {
+    function testGovernMint() public {
       address db = address(0xdeadbeef);
 
       ClubSig.Club[] memory clubs = new ClubSig.Club[](1);
@@ -64,5 +64,16 @@ contract ClubSigTest is DSTestPlus {
 
       vm.prank(address(clubSig));
       clubSig.govern(clubs, mints, 3);
+    }
+
+    function testGovernBurn() public {
+      ClubSig.Club[] memory clubs = new ClubSig.Club[](1);
+      clubs[0] = ClubSig.Club(alice, 1, 100);
+
+      bool[] memory mints = new bool[](1);
+      mints[0] = false;
+
+      vm.prank(address(clubSig));
+      clubSig.govern(clubs, mints, 1);
     }
 }

--- a/src/test/ClubSig.t.sol
+++ b/src/test/ClubSig.t.sol
@@ -40,4 +40,29 @@ contract ClubSigTest is DSTestPlus {
       vm.expectRevert(bytes4(keccak256("Forbidden()")));
       clubSig.flipGovernor(charlie);
     }
+
+    function testGovernAlreadyMinted() public {
+      ClubSig.Club[] memory clubs = new ClubSig.Club[](1);
+      clubs[0] = ClubSig.Club(alice, 0, 100);
+
+      bool[] memory mints = new bool[](1);
+      mints[0] = true;
+
+      vm.expectRevert(bytes4(keccak256("AlreadyMinted()")));
+      vm.prank(address(clubSig));
+      clubSig.govern(clubs, mints, 3);
+    }
+
+    function testGovern() public {
+      address db = address(0xdeadbeef);
+
+      ClubSig.Club[] memory clubs = new ClubSig.Club[](1);
+      clubs[0] = ClubSig.Club(db, 2, 100);
+
+      bool[] memory mints = new bool[](1);
+      mints[0] = true;
+
+      vm.prank(address(clubSig));
+      clubSig.govern(clubs, mints, 3);
+    }
 }


### PR DESCRIPTION
Includes the following updates:
* fix an underflow issue caused when govern() is only called to burn
* optimize storage reads for `totalSupply` in `govern()`
* unit tests