### PR TITLE
Remove unnecessary notPaused modifiers

### DIFF
--- a/src/ClubNFT.sol
+++ b/src/ClubNFT.sol
@@ -215,7 +215,7 @@ abstract contract ClubNFT {
         address from, 
         address to, 
         uint256 id
-    ) public payable notPaused {
+    ) public payable {
         transferFrom(from, to, id); 
 
         if (to.code.length != 0 
@@ -229,7 +229,7 @@ abstract contract ClubNFT {
         address to, 
         uint256 id, 
         bytes calldata data
-    ) public payable notPaused {
+    ) public payable {
         transferFrom(from, to, id); 
         
         if (to.code.length != 0 


### PR DESCRIPTION
It's not necessary to have the `notPaused` modifier on `safeTransferFrom` because the `notPaused` modifier already exists on the `transferFrom` function.

Removing it saves an SLOAD (100 gas).