### PR TITLE
consolid

### DIFF
--- a/src/KaliClubSig.sol
+++ b/src/KaliClubSig.sol
@@ -237,41 +237,39 @@ contract KaliClubSig is ClubNFT, IClub, Multicall {
         bool deleg,
         Signature[] calldata sigs
     ) external payable returns (bool success) {
-        // governor has admin privileges to execute without quorum
-        if (!governor[msg.sender]) {
-            bytes32 digest = getDigest(to, value, data, deleg, nonce);
+        bytes32 digest = getDigest(to, value, data, deleg, nonce);
 
-            // starting from the zero address here to ensure that all addresses are greater than
-            address prevAddr;
+        // starting from the zero address here to ensure that all addresses are greater than
+        address prevAddr;
 
-            for (uint256 i; i < quorum; ) {
-                address signer = ecrecover(
-                    digest,
-                    sigs[i].v,
-                    sigs[i].r,
-                    sigs[i].s
-                );
-                // check for conformant contract signature using EIP-1271
-                // - branching on whether signer address is a contract
-                if (signer.code.length != 0) {
-                    if (
-                        IERC1271(signer).isValidSignature(
-                            digest,
-                            abi.encodePacked(sigs[i].r, sigs[i].s, sigs[i].v)
-                        ) != IERC1271.isValidSignature.selector // magic value
-                    ) revert WrongSigner();
-                }
-                // check for NFT balance and duplicates
-                if (balanceOf[signer] == 0 || prevAddr >= signer)
-                    revert WrongSigner();
-                // set prevAddr to signer for the next iteration until we've reached quorum
-                prevAddr = signer;
-                // cannot realistically overflow on human timescales
-                unchecked {
-                    ++i;
-                }
+        for (uint256 i; i < quorum; ) {
+            address signer = ecrecover(
+                digest,
+                sigs[i].v,
+                sigs[i].r,
+                sigs[i].s
+            );
+            // check for conformant contract signature using EIP-1271
+            // - branching on whether signer address is a contract
+            if (signer.code.length != 0) {
+                if (
+                    IERC1271(signer).isValidSignature(
+                        digest,
+                        abi.encodePacked(sigs[i].r, sigs[i].s, sigs[i].v)
+                    ) != IERC1271.isValidSignature.selector
+                ) revert WrongSigner();
+            }
+            // check for NFT balance and duplicates
+            if (balanceOf[signer] == 0 || prevAddr >= signer)
+                revert WrongSigner();
+            // set prevAddr to signer for the next iteration until we've reached quorum
+            prevAddr = signer;
+            // cannot realistically overflow on human timescales
+            unchecked {
+                ++i;
             }
         }
+        
         if (!deleg) {
             // if this is not a delegated call
             assembly {

--- a/src/test/KaliClubSig.t.sol
+++ b/src/test/KaliClubSig.t.sol
@@ -398,7 +398,7 @@ contract ClubSigTest is Test {
 
         clubSig.batchExecute(call);
         vm.stopPrank();
-        assert(mockdai.balanceOf(alice) == 100);
+        assert(mockDai.balanceOf(alice) == 100);
         uint256 nonceAfter = clubSig.nonce();
         assert((nonceInit + 1) == nonceAfter);
     }

--- a/src/test/KaliClubSig.t.sol
+++ b/src/test/KaliClubSig.t.sol
@@ -5,7 +5,7 @@ import {IClub} from '../interfaces/IClub.sol';
 import {IRicardianLLC} from '../interfaces/IRicardianLLC.sol';
 
 import {ClubLoot} from '../ClubLoot.sol';
-import {Signature, KaliClubSig} from '../KaliClubSig.sol';
+import {Call, Signature, KaliClubSig} from '../KaliClubSig.sol';
 import {KaliClubSigFactory} from '../KaliClubSigFactory.sol';
 
 import {MockERC20} from '@solmate/test/utils/mocks/MockERC20.sol';
@@ -374,8 +374,6 @@ contract ClubSigTest is Test {
 
         address aliceAddress = address(alice);
 
-        Signature[] memory sigs = new Signature[](0);
-
         mockDai.transfer(address(clubSig), 100);
 
         startHoax(address(alice), address(alice), type(uint256).max);
@@ -391,8 +389,16 @@ contract ClubSigTest is Test {
             mstore(0x40, add(data, 0x100))
         }
 
-        clubSig.execute(address(mockDai), 0, data, false, sigs);
+        Call[] memory call = new Call[](1);
+
+        call[0].to = address(mockDai);
+        call[0].value = 0;
+        call[0].data = data;
+        call[0].deleg = false;
+
+        clubSig.batchExecute(call);
         vm.stopPrank();
+        assert(mockdai.balanceOf(alice) == 100);
         uint256 nonceAfter = clubSig.nonce();
         assert((nonceInit + 1) == nonceAfter);
     }


### PR DESCRIPTION
separate out gov call logic into batchExecute() 
this saves a storage read for normie calls